### PR TITLE
Modal Refactor to CSSTransitionGroup

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@ var Touchstone = {
 	createApp: require('./lib/createApp'),
 	Navigation: require('./lib/mixins/Navigation'),
 	Dialogs: require('./lib/mixins/Dialogs'),
+	Animation: require('./lib/mixins/Animation'),
 	Link: require('./lib/components/Link'),
 	UI: require('./lib/ui')
 };

--- a/lib/createApp.js
+++ b/lib/createApp.js
@@ -1,22 +1,7 @@
-var _ = require('underscore')
-var React = require('react/addons')
-var UI = require('./ui')
-
-var DEFAULT_TRANSITION = 'none';
-var TRANSITION_KEYS = [
-	'none',
-	'fade',
-	'fade-contract',
-	'fade-expand',
-	'show-from-left',
-	'show-from-right',
-	'show-from-top',
-	'show-from-bottom',
-	'reveal-from-left',
-	'reveal-from-right',
-	'reveal-from-top',
-	'reveal-from-bottom'
-];
+var _ = require('underscore');
+var React = require('react/addons');
+var UI = require('./ui');
+var Animation = require('./mixins/Animation');
 
 /**
  * Touchstone App
@@ -29,13 +14,14 @@ var TRANSITION_KEYS = [
 
 function createApp(views) {
 	return {
-
-		getInitialState: function() {
+		mixins: [Animation],
+		
+		getInitialState: function () {
 			return {
-				viewTransition: this.getViewTransition(DEFAULT_TRANSITION)
+				viewTransition: this.getViewTransition(this._DEFAULT_TRANSITION)
 			};
 		},
-
+		
 		componentWillMount: function() {
 			this.views = {};
 			_.each(views, function(view, key) {
@@ -89,36 +75,13 @@ function createApp(views) {
 			return views;
 		},
 
-		getViewTransition: function(key) {
-			if (!_.contains(TRANSITION_KEYS, key)) {
-				console.log('Invalid View Transition: ' + key);
-				key = 'none';
-			}
-			var transition = {
-				key: key,
-				name: 'view-transition-' + key,
-				in: false,
-				out: false
-			};
-			if (_.contains(['reveal-from-top', 'reveal-from-bottom'], key)) {
-				transition.out = true;
-			} else if (_.contains(['show-from-left', 'show-from-right', 'reveal-from-left', 'reveal-from-right'], key)) {
-				transition.in = true;
-				transition.out = true;
-			} else if (_.contains(['fade', 'fade-contract', 'fade-expand', 'show-from-top', 'show-from-bottom'], key)) {
-				transition.in = true;
-				transition.out = true;
-			}
-			return transition;
-		},
-
 		showView: function(key, transition, props, state) {
 			if (_.isObject(transition)) {
 				props = transition;
-				transition = DEFAULT_TRANSITION;
+				transition = this._DEFAULT_TRANSITION;
 			}
 			if (!_.isString(transition)) {
-				transition = DEFAULT_TRANSITION;
+				transition = this._DEFAULT_TRANSITION;
 			}
 
 			transition = this.getViewTransition(transition);

--- a/lib/mixins/Animation.js
+++ b/lib/mixins/Animation.js
@@ -1,0 +1,52 @@
+var React = require('react/addons');
+var _ = require('underscore');
+
+/**
+ * Touchstone Navigation Mixin
+ * ===========================
+ */
+
+
+
+module.exports = {
+
+	displayName: 'Animation',
+	
+	getViewTransition: function (key) {
+		if (!_.contains(this._TRANSITION_KEYS, key)) {
+			console.log('Invalid View Transition: ' + key);
+			key = 'none';
+		}
+		var transition = {
+			key: key,
+			name: 'view-transition-' + key,
+			in: false,
+			out: false
+		};
+		if (_.contains(['reveal-from-top', 'reveal-from-bottom'], key)) {
+			transition.out = true;
+		} else if (_.contains(['show-from-left', 'show-from-right', 'reveal-from-left', 'reveal-from-right'], key)) {
+			transition.in = true;
+			transition.out = true;
+		} else if (_.contains(['fade', 'fade-contract', 'fade-expand', 'show-from-top', 'show-from-bottom'], key)) {
+			transition.in = true;
+			transition.out = true;
+		}
+		return transition;
+	},
+	_DEFAULT_TRANSITION: 'none',
+	_TRANSITION_KEYS: [
+		'none',
+		'fade',
+		'fade-contract',
+		'fade-expand',
+		'show-from-left',
+		'show-from-right',
+		'show-from-top',
+		'show-from-bottom',
+		'reveal-from-left',
+		'reveal-from-right',
+		'reveal-from-top',
+		'reveal-from-bottom'
+	]
+};

--- a/lib/ui/Modal.js
+++ b/lib/ui/Modal.js
@@ -1,10 +1,13 @@
 var classnames = require('classnames');
 
 var React = require('react/addons');
+var ReactCSSTransitionGroup = React.addons.CSSTransitionGroup;
 var Tappable = require('react-tappable');
+var Animation = require('../mixins/Animation');
 
 module.exports = React.createClass({
 	displayName: 'Modal',
+	mixins: [Animation],
 	propTypes: {
 		className: React.PropTypes.string,
 		showModal: React.PropTypes.bool,
@@ -17,32 +20,10 @@ module.exports = React.createClass({
 		primaryActionText: React.PropTypes.string,
 		primaryActionFn: React.PropTypes.func,
 		secondaryActionText: React.PropTypes.string,
-		secondaryActionFn: React.PropTypes.func
+		secondaryActionFn: React.PropTypes.func,
+		viewTransition: React.PropTypes.string
 	},
-
-	getDefaultProps: function() {
-		return {
-			showModal: false
-		};
-	},
-
-	getInitialState: function() {
-		return {
-			showModal: this.props.showModal
-		};
-	},
-
-	// TODO: use ReactTransitionGroup to handle fade in/out
-	componentDidMount: function() {
-		var self = this;
-
-		setTimeout(function() {
-			if (!self.isMounted()) return
-
-			self.setState({ showModal: true });
-		}, 1);
-	},
-
+	
 	render: function() {
 		// Set classnames
 		var dialogClassName = classnames({
@@ -51,13 +32,20 @@ module.exports = React.createClass({
 			'Modal-loading': this.props.loading
 		}, this.props.className);
 		var modalClassName = classnames('Modal', {
-			'enter': this.state.showModal
+			'enter': this.props.showModal
 		});
+		var transitionName = (this.props.viewTransition) ? (this.props.viewTransition) : this._DEFAULT_TRANSITION;
+		var viewTransition = this.getViewTransition(transitionName);
 
 		// Set dynamic content
 		var icon = this.props.iconKey ? <div className={'Modal-icon ' + this.props.iconKey + ' ' + this.props.iconType} /> : null;
 		var header = this.props.header ? <div className="Modal-header">{this.props.header}</div> : null;
-		var text = this.props.text ? <div className="Modal-text" dangerouslySetInnerHTML={{__html: this.props.text}} /> : null;
+		var content;
+		if(this.props.text){
+			content = <div className="Modal-text">{this.props.text}</div>
+		} else {
+			content = <div className="Modal-text">{this.props.children}</div>
+		}
 		var primaryAction = this.props.primaryActionText ? <Tappable onTap={this.props.primaryActionFn} className="Modal-action Modal-action-primary">{this.props.primaryActionText}</Tappable> : null;
 		var secondaryAction = this.props.secondaryActionText ? <Tappable onTap={this.props.secondaryActionFn} className="Modal-action Modal-action-secondary">{this.props.secondaryActionText}</Tappable> : null;
 
@@ -65,17 +53,23 @@ module.exports = React.createClass({
 			{secondaryAction}
 			{primaryAction}
 		</div> ) : null;
+		
 
-		return (
+		var modal = this.props.showModal ?  (
 			<div className={modalClassName}>
 				<div className={dialogClassName}>
 					{icon}
 					{header}
-					{text}
+					{content}
 					{actions}
 				</div>
 				<div className="Modal-backdrop" />
 			</div>
-		);
+		) : null;
+		
+		return(
+			<ReactCSSTransitionGroup transitionName={viewTransition.name} transitionEnter={viewTransition.in} transitionLeave={viewTransition.out} className="view-wrapper" component="div">
+				{modal}
+			</ReactCSSTransitionGroup>)
 	}
 });


### PR DESCRIPTION
I wanted to use the Modal, but in its current version somehow it was always visible, since the visibility depended on showModal state, which was automatically.

I have also refactored it to ReactCSSTransitionGroup for Animations. In order to access the default animations of Touchstone I have taken them from "createApp" into an extra mixin, which can now be used by anyone in any other component, if they want to "animate" things with touchstone animations.

I also added the possibility to provide the content of the Modal as child props, which should make it especially for more complex HTML or JSX more comfortable to provide content to the modal.