### PR TITLE
Simpler Router architecture

### DIFF
--- a/lib/createApp.js
+++ b/lib/createApp.js
@@ -51,33 +51,26 @@ function createApp(views) {
 		},
 
 		getCurrentView: function() {
-			var views = {};
-			views[this.state.currentView] = this.getView(this.state.currentView);
-			return views;
+			var key = this.state.currentView
+			var view = views[key]
+			if (!view) return this.getViewNotFound()
+
+			var viewProps = xtend({
+				app: this,
+				key: key
+			}, this.state.__viewProps)
+
+			if (this.getViewProps) {
+				xtend(viewProps, this.getViewProps())
+			}
+
+			return React.createElement(view, viewProps)
 		},
 
 		getInitialState: function() {
 			return {
 				viewTransition: this.getViewTransition(DEFAULT_TRANSITION)
-			};
-		},
-
-		getView: function(key) {
-			var view = views[key];
-			if (!view) return this.getViewNotFound()
-
-			var givenProps = this.state[key + '_props']
-			var props = xtend({
-				key: key,
-				app: this,
-				viewClassName: this.state[key + '_class'] || 'view'
-			}, givenProps)
-
-			if (this.getViewProps) {
-				xtend(props, this.getViewProps())
 			}
-
-			return React.createElement(view, props)
 		},
 
 		getViewNotFound: function() {
@@ -93,7 +86,7 @@ function createApp(views) {
 						/>
 					</UI.FlexBlock>
 				</UI.FlexLayout>
-			);
+			)
 		},
 
 		getViewTransition: function(key) {
@@ -120,20 +113,15 @@ function createApp(views) {
 				transition = DEFAULT_TRANSITION
 			}
 
-			console.log('Showing view |' + key + '| with transition |' + transition.key + '| and props ' + JSON.stringify(props));
+			console.log('Showing view |' + key + '| with transition |' + transition.key + '| and props ' + JSON.stringify(props))
 
-			var newState = {
+			var newState = xtend({
 				currentView: key,
-				previousView: this.state.currentView,
-				viewTransition: this.getViewTransition(transition)
-			};
+				viewTransition: this.getViewTransition(transition),
+				__viewProps: props
+			}, state)
 
-			newState[key + '_class'] = 'view';
-			newState[key + '_props'] = props || {};
-
-			xtend(newState, state);
-
-			this.setState(newState);
+			this.setState(newState)
 		}
 	}
 }


### PR DESCRIPTION
This pull request removes `getView` from the Application API,  introducing a breaking change.

This has been done to reduce the Application from storing props beyond the view it currently is showing,  more in line with how this module is expected (and almost always is) to be used.

This is of benefit to most applications as until now you could find view `prop` information that may be been left in the applications state,  causing excessive memory usage and potential security concerns.