### PR TITLE
KeypadButton rework [breaking change]

### DIFF
--- a/src/ui/KeypadButton.js
+++ b/src/ui/KeypadButton.js
@@ -18,10 +18,8 @@ module.exports = React.createClass({
 
 	getDefaultProps: function () {
 		return {
-			action: function() {},
-			className: '',
-			secondaryLabel: ''
-		}
+			action: function () {}
+		};
 	},
 
 	render: function () {

--- a/src/ui/KeypadButton.js
+++ b/src/ui/KeypadButton.js
@@ -10,6 +10,7 @@ module.exports = React.createClass({
 		aux: React.PropTypes.bool,
 		className: React.PropTypes.string,
 		disabled: React.PropTypes.bool,
+		icon: React.PropTypes.string,
 		primaryLabel: React.PropTypes.string,
 		secondaryLabel: React.PropTypes.string,
 		value: React.PropTypes.string

--- a/src/ui/KeypadButton.js
+++ b/src/ui/KeypadButton.js
@@ -9,7 +9,6 @@ module.exports = React.createClass({
 		action: React.PropTypes.func,
 		aux: React.PropTypes.bool,
 		className: React.PropTypes.string,
-		delete: React.PropTypes.bool,
 		disabled: React.PropTypes.bool,
 		primaryLabel: React.PropTypes.string,
 		secondaryLabel: React.PropTypes.string,
@@ -26,7 +25,7 @@ module.exports = React.createClass({
 
 	render: function() {
 		var className = classnames('Keypad-button', {
-			'is-auxiliary': this.props.aux || this.props.delete,
+			'is-auxiliary': this.props.aux,
 			'disabled': this.props.disabled
 		});
 

--- a/src/ui/KeypadButton.js
+++ b/src/ui/KeypadButton.js
@@ -1,7 +1,7 @@
-var classnames = require('classnames')
+var classnames = require('classnames');
 
-var React = require('react/addons')
-var Tappable = require('react-tappable')
+var React = require('react/addons');
+var Tappable = require('react-tappable');
 
 module.exports = React.createClass({
 	displayName: 'KeypadButton',
@@ -16,7 +16,7 @@ module.exports = React.createClass({
 		value: React.PropTypes.string
 	},
 
-	getDefaultProps: function() {
+	getDefaultProps: function () {
 		return {
 			action: function() {},
 			className: '',
@@ -24,7 +24,7 @@ module.exports = React.createClass({
 		}
 	},
 
-	render: function() {
+	render: function () {
 		var className = classnames('Keypad-button', {
 			'is-auxiliary': this.props.aux,
 			'disabled': this.props.disabled


### PR DESCRIPTION
*Breaking change* - Removes `delete` prop

On further review of https://github.com/touchstonejs/touchstonejs/pull/65,  I think @KeKs0r had a point in removing the `delete` prop in KeypadButton.js.

@jossmac it'd be good if we swapped out `this.props.icon` with `this.props.children` for users, like we did with `Popup`.  Thoughts?