### PR TITLE
PopupIcon: use oneOf to limit types

### DIFF
--- a/src/ui/PopupIcon.js
+++ b/src/ui/PopupIcon.js
@@ -1,15 +1,15 @@
 var React = require('react/addons');
-
 var classNames = require('classnames');
 
 module.exports = React.createClass({
 	displayName: 'PopupIcon',
 	propTypes: {
 		name: React.PropTypes.string,
-		type: React.PropTypes.string,
+		type: React.PropTypes.oneOf(['default', 'muted', 'primary', 'success', 'warning', 'danger']),
 		spinning: React.PropTypes.bool
 	},
-	render: function() {
+
+	render: function () {
 		var className = classNames('Modal-icon', {
 			'is-spinning': this.props.spinning
 		}, this.props.name, this.props.type);


### PR DESCRIPTION
Thanks @KeKs0r.

I couldn't merge https://github.com/touchstonejs/touchstonejs/pull/66 because it needed to be rebased without being chained on top of #65 .

But it was a good change none the less.

