### PR TITLE
Allow NavigationBar to use className prop

### DIFF
--- a/src/ui/NavigationBar.js
+++ b/src/ui/NavigationBar.js
@@ -39,7 +39,8 @@ var NavigationBar = React.createClass({
 	},
 
 	propTypes: {
-		name: React.PropTypes.string
+		name: React.PropTypes.string,
+		className: React.PropTypes.string
 	},
 
 	getInitialState () {
@@ -182,7 +183,7 @@ var NavigationBar = React.createClass({
 
 	render () {
 		return (
-			<div className="NavigationBar">
+			<div className={classNames("NavigationBar", this.props.className)}>
 				{this.renderLeftButton()}
 				{this.renderTitle()}
 				{this.renderRightButton()}


### PR DESCRIPTION
Without this, if a parent wants to style the component, it has to use a wrapper element if it wants to only a single NavigationBar. This allows the composer to style this component individually, without worrying about affecting other NavigationBars.