### PR TITLE
remove .views

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -13,7 +13,6 @@ export function createApp () {
 	var app = {
 		navigationBars: {},
 		viewManagers: {},
-		views: {},
 		transitionTo (view, opts) {
 			var vm = '__default';
 			view = view.split(':');


### PR DESCRIPTION
Resolves https://github.com/touchstonejs/touchstonejs/issues/70

`.views` is unused,  as all views are nested inside `ViewManagers` as children.