### PR TITLE
Yet another react 0.1.4 upgrade PR

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,9 @@
   "dependencies": {
     "blacklist": "^1.1.2",
     "classnames": "^2.1.3",
-    "tween.js": "^0.14.0",
+    "tween.js": "^0.14.0"
+  },
+  "peerDependencies": {
     "react": "^0.14.0",
     "react-dom": "^0.14.0",
     "react-container": "^0.3.0",

--- a/package.json
+++ b/package.json
@@ -41,10 +41,12 @@
   "dependencies": {
     "blacklist": "^1.1.2",
     "classnames": "^2.1.3",
-    "react": "^0.13.3",
-    "react-container": "^0.2.4",
-    "react-tappable": "^0.6.0",
-    "tween.js": "^0.14.0"
+    "tween.js": "^0.14.0",
+    "react": "^0.14.0",
+    "react-dom": "^0.14.0",
+    "react-container": "^0.3.0",
+    "react-tappable": "^0.7.1",
+    "react-addons-css-transition-group": "^0.14.0"
   },
   "devDependencies": {
     "babel-core": "^5.8.25",
@@ -52,7 +54,7 @@
     "babelify": "^6.3.0",
     "browserify": "^11.2.0",
     "del": "^2.0.2",
-    "elemental": "^0.1.1",
+    "elemental": "^0.5.5",
     "gulp": "^3.9.0",
     "gulp-babel": "^5.2.1",
     "gulp-bump": "^1.0.0",

--- a/src/core/ViewManager.js
+++ b/src/core/ViewManager.js
@@ -1,8 +1,8 @@
 var blacklist = require('blacklist');
 var classNames = require('classnames');
 var ErrorView = require('./ErrorView');
-var React = require('react/addons');
-var Transition = React.addons.CSSTransitionGroup;
+var React = require('react');
+var ReactCSSTransitionGroup = require('react-addons-css-transition-group');
 
 function createViewsFromChildren (children) {
 	var views = {};
@@ -142,9 +142,9 @@ var ViewManager = React.createClass({
 			transitionName = 'view-transition-' + this.state.options.transition;
 		}
 		return (
-			<Transition transitionName={transitionName} transitionEnter={true} transitionLeave={true} className={className} component="div">
+			<ReactCSSTransitionGroup transitionName={transitionName} transitionEnter={true} transitionLeave={true} className={className} component="div">
 				{viewContainer}
-			</Transition>
+			</ReactCSSTransitionGroup>
 		);
 	}
 });

--- a/src/core/animation.js
+++ b/src/core/animation.js
@@ -1,5 +1,4 @@
 var animation = require('tween.js');
-var ReactDOM = require('react-dom');
 
 function update () {
 	animation.update();
@@ -50,7 +49,7 @@ Mixins.ScrollContainerToTop = {
 	},
 	scrollContainerToTop () {
 		if (!this.isMounted() || !this.refs.scrollContainer) return;
-		this._scrollContainerAnimation = scrollToTop(ReactDOM.findNode(this.refs.scrollContainer), {
+		this._scrollContainerAnimation = scrollToTop(this.refs.scrollContainer, {
 			onComplete: () => { delete this._scrollContainerAnimation; }
 		});
 	}

--- a/src/core/animation.js
+++ b/src/core/animation.js
@@ -1,5 +1,5 @@
 var animation = require('tween.js');
-var React = require('react');
+var ReactDOM = require('react-dom');
 
 function update () {
 	animation.update();
@@ -50,7 +50,7 @@ Mixins.ScrollContainerToTop = {
 	},
 	scrollContainerToTop () {
 		if (!this.isMounted() || !this.refs.scrollContainer) return;
-		this._scrollContainerAnimation = scrollToTop(React.findDOMNode(this.refs.scrollContainer), {
+		this._scrollContainerAnimation = scrollToTop(ReactDOM.findNode(this.refs.scrollContainer), {
 			onComplete: () => { delete this._scrollContainerAnimation; }
 		});
 	}

--- a/src/ui/Alertbar.js
+++ b/src/ui/Alertbar.js
@@ -1,6 +1,6 @@
-var React = require('react/addons');
+var React = require('react');
 var classnames = require('classnames');
-var Transition = React.addons.CSSTransitionGroup;
+var ReactCSSTransitionGroup = require('react-addons-css-transition-group');
 
 module.exports = React.createClass({
 	displayName: 'Alertbar',
@@ -29,9 +29,9 @@ module.exports = React.createClass({
 		var animatedBar = this.props.visible ? <div className={className}>{pulseWrap}</div> : null;
 
 		var component = this.props.animated ? (
-			<Transition transitionName="Alertbar" component="div">
+			<ReactCSSTransitionGroup transitionName="Alertbar" transitionEnterTimeout={300} transitionLeaveTimeout={300} component="div">
 				{animatedBar}
-			</Transition>
+			</ReactCSSTransitionGroup>
 		) : <div className={className}>{pulseWrap}</div>;
 
 		return component;

--- a/src/ui/Button.js
+++ b/src/ui/Button.js
@@ -1,4 +1,4 @@
-var React = require('react/addons');
+var React = require('react');
 var Tappable = require('react-tappable');
 
 var blacklist = require('blacklist');

--- a/src/ui/ButtonGroup.js
+++ b/src/ui/ButtonGroup.js
@@ -1,6 +1,6 @@
 var blacklist = require('blacklist');
 var classnames = require('classnames');
-var React = require('react/addons');
+var React = require('react');
 
 module.exports = React.createClass({
 	displayName: 'ButtonGroup',

--- a/src/ui/DatePicker.js
+++ b/src/ui/DatePicker.js
@@ -1,4 +1,4 @@
-var React = require('react/addons');
+var React = require('react');
 var Tappable = require('react-tappable');
 var classnames = require('classnames');
 

--- a/src/ui/DatePickerPopup.js
+++ b/src/ui/DatePickerPopup.js
@@ -1,5 +1,5 @@
 var blacklist = require('blacklist');
-var React = require('react/addons');
+var React = require('react');
 var Popup = require('./Popup');
 var DatePicker = require('./DatePicker');
 var classnames = require('classnames');

--- a/src/ui/FieldControl.js
+++ b/src/ui/FieldControl.js
@@ -1,6 +1,6 @@
 var blacklist = require('blacklist');
 var classnames = require('classnames');
-var React = require('react/addons');
+var React = require('react');
 
 module.exports = React.createClass({
 	displayName: 'FieldControl',

--- a/src/ui/FieldLabel.js
+++ b/src/ui/FieldLabel.js
@@ -1,6 +1,6 @@
 var blacklist = require('blacklist');
 var classnames = require('classnames');
-var React = require('react/addons');
+var React = require('react');
 
 module.exports = React.createClass({
 	displayName: 'FieldLabel',

--- a/src/ui/Group.js
+++ b/src/ui/Group.js
@@ -1,6 +1,6 @@
 var blacklist = require('blacklist');
 var classnames = require('classnames');
-var React = require('react/addons');
+var React = require('react');
 
 module.exports = React.createClass({
 	displayName: 'Group',

--- a/src/ui/GroupBody.js
+++ b/src/ui/GroupBody.js
@@ -1,6 +1,6 @@
 var blacklist = require('blacklist');
 var classnames = require('classnames');
-var React = require('react/addons');
+var React = require('react');
 
 module.exports = React.createClass({
 	displayName: 'GroupBody',

--- a/src/ui/GroupFooter.js
+++ b/src/ui/GroupFooter.js
@@ -1,6 +1,6 @@
 var blacklist = require('blacklist');
 var classnames = require('classnames');
-var React = require('react/addons');
+var React = require('react');
 
 module.exports = React.createClass({
 	displayName: 'GroupFooter',

--- a/src/ui/GroupHeader.js
+++ b/src/ui/GroupHeader.js
@@ -1,6 +1,6 @@
 var blacklist = require('blacklist');
 var classnames = require('classnames');
-var React = require('react/addons');
+var React = require('react');
 
 module.exports = React.createClass({
 	displayName: 'GroupHeader',

--- a/src/ui/GroupInner.js
+++ b/src/ui/GroupInner.js
@@ -1,6 +1,6 @@
 var blacklist = require('blacklist');
 var classnames = require('classnames');
-var React = require('react/addons');
+var React = require('react');
 
 module.exports = React.createClass({
 	displayName: 'GroupInner',

--- a/src/ui/Input.js
+++ b/src/ui/Input.js
@@ -1,5 +1,5 @@
 import blacklist from 'blacklist';
-import React from 'react/addons';
+import React from 'react';
 
 import Item from './Item';
 import ItemContent from './ItemContent';

--- a/src/ui/Item.js
+++ b/src/ui/Item.js
@@ -1,5 +1,5 @@
 import blacklist from 'blacklist';
-import React from 'react/addons';
+import React from 'react';
 import classnames from 'classnames';
 
 module.exports = React.createClass({

--- a/src/ui/ItemContent.js
+++ b/src/ui/ItemContent.js
@@ -1,6 +1,6 @@
 var blacklist = require('blacklist');
 var classnames = require('classnames');
-var React = require('react/addons');
+var React = require('react');
 
 module.exports = React.createClass({
 	displayName: 'ItemContent',

--- a/src/ui/ItemInner.js
+++ b/src/ui/ItemInner.js
@@ -1,4 +1,4 @@
-var React = require('react/addons');
+var React = require('react');
 
 var classnames = require('classnames');
 

--- a/src/ui/ItemMedia.js
+++ b/src/ui/ItemMedia.js
@@ -1,4 +1,4 @@
-var React = require('react/addons');
+var React = require('react');
 var classnames = require('classnames');
 
 module.exports = React.createClass({

--- a/src/ui/ItemNote.js
+++ b/src/ui/ItemNote.js
@@ -1,5 +1,5 @@
 var classnames = require('classnames');
-var React = require('react/addons');
+var React = require('react');
 
 module.exports = React.createClass({
 	displayName: 'ItemNote',

--- a/src/ui/ItemSubTitle.js
+++ b/src/ui/ItemSubTitle.js
@@ -1,6 +1,6 @@
 var blacklist = require('blacklist');
 var classnames = require('classnames');
-var React = require('react/addons');
+var React = require('react');
 
 module.exports = React.createClass({
 	displayName: 'ItemSubTitle',

--- a/src/ui/ItemTitle.js
+++ b/src/ui/ItemTitle.js
@@ -1,6 +1,6 @@
 var blacklist = require('blacklist');
 var classnames = require('classnames');
-var React = require('react/addons');
+var React = require('react');
 
 module.exports = React.createClass({
 	displayName: 'ItemTitle',

--- a/src/ui/LabelInput.js
+++ b/src/ui/LabelInput.js
@@ -2,7 +2,7 @@ import blacklist from 'blacklist';
 import FieldControl from './FieldControl';
 import Item from './Item';
 import ItemInner from './ItemInner';
-import React from 'react/addons';
+import React from 'react';
 import Tappable from 'react-tappable';
 
 // Many input types DO NOT support setSelectionRange.

--- a/src/ui/LabelSelect.js
+++ b/src/ui/LabelSelect.js
@@ -1,4 +1,4 @@
-import React from 'react/addons';
+import React from 'react';
 
 import FieldControl from './FieldControl';
 import FieldLabel from './FieldLabel';

--- a/src/ui/LabelTextarea.js
+++ b/src/ui/LabelTextarea.js
@@ -1,6 +1,6 @@
 var blacklist = require('blacklist');
 var classnames = require('classnames');
-var React = require('react/addons');
+var React = require('react');
 
 module.exports = React.createClass({
 	displayName: 'LabelTextarea',

--- a/src/ui/LabelValue.js
+++ b/src/ui/LabelValue.js
@@ -1,7 +1,7 @@
 import FieldControl from './FieldControl';
 import Item from './Item';
 import ItemInner from './ItemInner';
-import React from 'react/addons';
+import React from 'react';
 import classnames from 'classnames';
 
 module.exports = React.createClass({

--- a/src/ui/NavigationBar.js
+++ b/src/ui/NavigationBar.js
@@ -1,7 +1,7 @@
 var classNames = require('classnames');
-var React = require('react/addons');
+var React = require('react');
 var Tappable = require('react-tappable');
-var Transition = React.addons.CSSTransitionGroup;
+var ReactCSSTransitionGroup = require('react-addons-css-transition-group');
 
 const DIRECTIONS = {
 	'reveal-from-right': -1,
@@ -110,9 +110,9 @@ var NavigationBar = React.createClass({
 		var arrow = this.state.leftArrow ? <span className="NavigationBarLeftArrow" /> : null;
 
 		return (
-			<Transition transitionName={transitionName}>
+			<ReactCSSTransitionGroup transitionName={transitionName}>
 				{arrow}
-			</Transition>
+			</ReactCSSTransitionGroup>
 		);
 	},
 
@@ -127,9 +127,9 @@ var NavigationBar = React.createClass({
 		}
 
 		return (
-			<Transition transitionName={transitionName}>
+			<ReactCSSTransitionGroup transitionName={transitionName}>
 				<span key={Date.now()} className="NavigationBarLeftLabel">{this.state.leftLabel}</span>
-			</Transition>
+			</ReactCSSTransitionGroup>
 		);
 	},
 
@@ -145,9 +145,9 @@ var NavigationBar = React.createClass({
 		}
 
 		return (
-			<Transition transitionName={transitionName}>
+			<ReactCSSTransitionGroup transitionName={transitionName}>
 				{title}
-			</Transition>
+			</ReactCSSTransitionGroup>
 		);
 	},
 
@@ -163,9 +163,9 @@ var NavigationBar = React.createClass({
 			</Tappable>
 		) : null;
 		return (
-			<Transition transitionName={transitionName}>
+			<ReactCSSTransitionGroup transitionName={transitionName}>
 				{button}
-			</Transition>
+			</ReactCSSTransitionGroup>
 		);
 	},
 

--- a/src/ui/Popup.js
+++ b/src/ui/Popup.js
@@ -1,5 +1,5 @@
-var React = require('react/addons');
-var ReactCSSTransitionGroup = React.addons.CSSTransitionGroup;
+var React = require('react');
+var ReactCSSTransitionGroup = require('react-addons-css-transition-group');
 
 var classnames = require('classnames');
 
@@ -37,10 +37,10 @@ module.exports = React.createClass({
 	render () {
 		return (
 			<div className="Popup">
-				<ReactCSSTransitionGroup transitionName="Popup-dialog" component="div">
+				<ReactCSSTransitionGroup transitionName="Popup-dialog" transitionEnterTimeout={300} transitionLeaveTimeout={300} component="div">
 					{this.renderDialog()}
 				</ReactCSSTransitionGroup>
-				<ReactCSSTransitionGroup transitionName="Popup-background" component="div">
+				<ReactCSSTransitionGroup transitionName="Popup-background" transitionEnterTimeout={300} transitionLeaveTimeout={300} component="div">
 					{this.renderBackdrop()}
 				</ReactCSSTransitionGroup>
 			</div>

--- a/src/ui/PopupIcon.js
+++ b/src/ui/PopupIcon.js
@@ -1,4 +1,4 @@
-var React = require('react/addons');
+var React = require('react');
 var classNames = require('classnames');
 
 module.exports = React.createClass({

--- a/src/ui/SearchField.js
+++ b/src/ui/SearchField.js
@@ -1,5 +1,5 @@
 var classnames = require('classnames');
-var React = require('react/addons');
+var React = require('react');
 var Tappable = require('react-tappable');
 
 module.exports = React.createClass({

--- a/src/ui/Textarea.js
+++ b/src/ui/Textarea.js
@@ -1,4 +1,4 @@
-var React = require('react/addons');
+var React = require('react');
 
 var Item = require('./Item');
 var ItemContent = require('./ItemContent');


### PR DESCRIPTION
Just submitting the work I had already started few days ago, also took the change to move the dependencies into peerDependencies so we don't have to force host projects into a specific react version.

Upgrade went smoothly as described by #95 already, there isn't much differences between both, but I believe this one has less changes.

There is still warnings with ReactCSSTransitionGroup ``Failed propType: transitionEnterTimeout wasn't supplied to ReactCSSTransitionGroup`` that couldn't be fixed because it breaks the animations/transitions.

The touchstone starter and tasks projects need also to be updated to work correctly after this change.

fixes #89 #95 

Thanks